### PR TITLE
Update BKMN-NERO.config

### DIFF
--- a/configs/BKMN-NERO.config
+++ b/configs/BKMN-NERO.config
@@ -1,12 +1,13 @@
-# Betaflight / STM32F7X2 (S7X2) 4.2.0 May  5 2020 / 15:49:43 (b480103) MSP API: 1.43
+# Rotorflight / STM32F7X2 (S7X2) 4.3.0 Jan  9 2024 / 11:09:54 (norevision) MSP API: 12.3
 
-#define USE_GYRO
-#define USE_GYRO_SPI_ICM20602
+#define USE_ACC
+#define USE_ACC_SPI_ICM20602
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM20602
 #define USE_SDCARD
 
 board_name NERO
+board_design RTFL
 manufacturer_id BKMN
 
 # resources
@@ -101,7 +102,7 @@ dma pin C09 0
 
 # master
 set motor_pwm_protocol = PWM
-set dshot_burst = ON
+set dshot_bitbang = OFF
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0

--- a/configs/BKMN-NERO.config
+++ b/configs/BKMN-NERO.config
@@ -1,68 +1,79 @@
-# Betaflight / STM32F7X2 (S7X2) 4.0.0
+# Betaflight / STM32F7X2 (S7X2) 4.2.0 May  5 2020 / 15:49:43 (b480103) MSP API: 1.43
 
-# this will trigger the cloud build system to include these target defines.
-#define USE_ACC
-#define USE_ACC_SPI_MPU6500
 #define USE_GYRO
-#define USE_GYRO_SPI_MPU6500
+#define USE_GYRO_SPI_ICM20602
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM20602
+#define USE_SDCARD
 
 board_name NERO
 manufacturer_id BKMN
 
-# Basic I/O
+# resources
+resource BEEPER 1 C01
+resource LED_STRIP 1 B00 # pin M5
 resource LED 1 B06
 resource LED 2 B05
 resource LED 3 B04
-resource beeper C1
-resource I2C_SCL 1 B08
-resource I2C_SDA 1 B09
-resource SPI_SCK 1 A05
-resource SPI_MISO 1 A06
-resource SPI_MOSI 1 A07
-resource SPI_SCK 2 B13
-resource SPI_MISO 2 B14
-resource SPI_MOSI 2 B15
-resource SPI_SCK 3 C10
-resource SPI_MISO 3 C11
-resource SPI_MOSI 3 C12
-resource gyro_cs 1 C4
-resource GYRO_EXTI 1 B15
-resource SDCARD_CS 1 A15
-resource SDCARD_DETECT 1 D02
-resource MOTOR 1 A0
-resource MOTOR 2 A1
-resource MOTOR 3 A2
-resource MOTOR 4 A3
-resource LED_STRIP B0
-resource PPM C7
-resource SERIAL_TX 1 A9
+
+# Motors
+resource MOTOR 1 C08 # --> pin M7
+# resource MOTOR 2 C09 # --> pin M8
+resource SERVO 1 A00 # --> pin M1
+resource SERVO 2 A01 # --> pin M2
+resource SERVO 3 A02 # --> pin M3
+resource SERVO 4 B01 # --> pin M6
+resource FREQ 1 A03 # --> pin M4
+
+# UARTS
+resource SERIAL_TX 1 A09
 resource SERIAL_RX 1 A10
 resource SERIAL_TX 3 B10
 resource SERIAL_RX 3 B11
-resource SERIAL_TX 6 C6
-resource SERIAL_RX 6 C7
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 6 C07
+
+# IIC1
+resource I2C_SCL 1 B08
+resource I2C_SDA 1 B09
+
+# ADC
 resource ADC_BATT 1 C03
-resource ESCSERIAL 1 C07
+resource ADC_CURR 1 C02 # --> pin AD
+resource ADC_RSSI 1 A04 # --> pin DA
+
+# GYRO & ACC --> SPI1
+resource SPI_SCK 1 A05
+resource SPI_MISO 1 A06
+resource SPI_MOSI 1 A07
+resource GYRO_CS 1 C04
+resource GYRO_EXTI 1 B02
+
+# ACC_SPI --> SPI2
+resource SPI_SCK 2 B13
+resource SPI_MISO 2 B14
+resource SPI_MOSI 2 B15
+
+# SDCARD --> SPI3
+resource SPI_SCK 3 C10
+resource SPI_MISO 3 C11
+resource SPI_MOSI 3 C12
 resource SDCARD_CS 1 A15
 resource SDCARD_DETECT 1 D02
 
-# Timers
-# First four timers
-# timer is zero origin
+# timer 
 timer A00 AF2
 # pin A00: TIM5 CH1 (AF2)
 timer A01 AF2
 # pin A01: TIM5 CH2 (AF2)
 timer A02 AF2
 # pin A02: TIM5 CH3 (AF2)
-timer A03 AF2
-# pin A03: TIM5 CH4 (AF2)
-timer B00 AF2
-# pin B00: TIM3 CH3 (AF2)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B00 AF1
+# pin B00: TIM1 CH2N (AF1)
 timer B01 AF2
 # pin B01: TIM3 CH4 (AF2)
-timer C07 AF3
-# pin C07: TIM8 CH2 (AF3)
 timer C08 AF3
 # pin C08: TIM8 CH3 (AF3)
 timer C09 AF3
@@ -71,39 +82,38 @@ timer C09 AF3
 # dma
 dma ADC 1 1
 # ADC 1: DMA2 Stream 4 Channel 0
-dma pin B04 0
-# pin B04: DMA1 Stream 4 Channel 5
-dma pin B05 0
-# pin B05: DMA1 Stream 5 Channel 5
-dma pin B00 0
-# pin B00: DMA1 Stream 7 Channel 5
-dma pin B01 0
-# pin B01: DMA1 Stream 2 Channel 5
-dma pin A15 0
-# pin A15: DMA1 Stream 5 Channel 3
-dma pin B03 0
-# pin B03: DMA1 Stream 6 Channel 3
-dma pin B06 0
-# pin B06: DMA1 Stream 0 Channel 2
-dma pin B07 0
-# pin B07: DMA1 Stream 3 Channel 2
-dma pin A08 2
-# pin A08: DMA2 Stream 3 Channel 6
-dma pin A01 0
-# pin A01: DMA1 Stream 4 Channel 6
 dma pin A00 0
 # pin A00: DMA1 Stream 2 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+dma pin A02 0
+# pin A02: DMA1 Stream 0 Channel 6
+dma pin A03 0
+# pin A03: DMA1 Stream 7 Channel 3
+dma pin B00 0
+# pin B00: DMA2 Stream 6 Channel 0
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C08 0
+# pin C08: DMA2 Stream 2 Channel 0
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
 
-feature RX_SERIAL
-
+# master
+set motor_pwm_protocol = PWM
 set dshot_burst = ON
-set beeper_inversion = ON
-set beeper_od = OFF
 set gyro_1_bustype = SPI
 set gyro_1_spibus = 1
 set gyro_1_sensor_align = CW0
-set sdcard_detect_inverted = ON
+set blackbox_device = SDCARD
 set sdcard_mode = SPI
 set sdcard_spi_bus = 3
-serial 5 64 115200 57600 0 115200
+set sdcard_detect_inverted = ON
+set beeper_inversion = ON
+set beeper_od = OFF
+set current_meter = ADC
 set battery_meter = ADC
+set mag_hardware = NONE
+set baro_hardware = NONE
+
+


### PR DESCRIPTION
The old BKMN NERO F7 target contains many incorrect resources. I have tested all pins from the pins headers back to the MCU and corrected the target accordingly.

This new target is as per RF2 requirement.

Please merge into master.