### PR TITLE
Add MOLE-MOLITE200 target configuration

### DIFF
--- a/configs/MOLE-MOLITE200.config
+++ b/configs/MOLE-MOLITE200.config
@@ -1,7 +1,7 @@
 # version
 # Rotorflight / STM32F7X2 (S7X2) 4.6.0-RC2 Apr 26 2026 / 17:42:21 (edaf83c) MSP API: 12.9
 
-board_name MoLite200
+board_name MOLITE200
 board_design YELLOWMOLE
 manufacturer_id MOLE
 

--- a/configs/MoLite200.config
+++ b/configs/MoLite200.config
@@ -1,0 +1,304 @@
+# version
+# Rotorflight / STM32F7X2 (S7X2) 4.6.0-RC2 Apr 26 2026 / 17:42:21 (edaf83c) MSP API: 12.9
+
+board_name MoLite200
+board_design YELLOWMOLE
+manufacturer_id MOLE
+
+# resources
+resource BEEPER 1 B08
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 NONE
+resource MOTOR 4 NONE
+resource SERVO 1 B10
+resource SERVO 2 B11
+resource SERVO 3 A10
+resource SERVO 4 B09
+resource SERVO 5 NONE
+resource SERVO 6 NONE
+resource SERVO 7 NONE
+resource SERVO 8 NONE
+resource SERVO 9 NONE
+resource SERVO 10 NONE
+resource SERVO 11 NONE
+resource SERVO 12 NONE
+resource SERVO 13 NONE
+resource SERVO 14 NONE
+resource SERVO 15 NONE
+resource SERVO 16 NONE
+resource SERVO 17 NONE
+resource SERVO 18 NONE
+resource SERVO 19 NONE
+resource SERVO 20 NONE
+resource SERVO 21 NONE
+resource SERVO 22 NONE
+resource SERVO 23 NONE
+resource SERVO 24 NONE
+resource SERVO 25 NONE
+resource SERVO 26 NONE
+resource PPM 1 NONE
+resource PWM 1 NONE
+resource PWM 2 NONE
+resource PWM 3 NONE
+resource PWM 4 NONE
+resource PWM 5 NONE
+resource PWM 6 NONE
+resource PWM 7 NONE
+resource PWM 8 NONE
+resource LED_STRIP 1 B01
+resource SERIAL_TX 1 NONE
+resource SERIAL_TX 2 NONE
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_TX 6 NONE
+resource SERIAL_TX 7 NONE
+resource SERIAL_TX 8 NONE
+resource SERIAL_TX 9 NONE
+resource SERIAL_TX 10 NONE
+resource SERIAL_TX 11 NONE
+resource SERIAL_TX 12 NONE
+resource SERIAL_RX 1 NONE
+resource SERIAL_RX 2 NONE
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource SERIAL_RX 6 NONE
+resource SERIAL_RX 7 NONE
+resource SERIAL_RX 8 NONE
+resource SERIAL_RX 9 NONE
+resource SERIAL_RX 10 NONE
+resource SERIAL_RX 11 NONE
+resource SERIAL_RX 12 NONE
+resource I2C_SCL 1 B06
+resource I2C_SCL 2 NONE
+resource I2C_SCL 3 A08
+resource I2C_SCL 4 NONE
+resource I2C_SDA 1 B07
+resource I2C_SDA 2 NONE
+resource I2C_SDA 3 C09
+resource I2C_SDA 4 NONE
+resource LED 1 C13
+resource LED 2 C14
+resource LED 3 NONE
+resource RX_BIND 1 NONE
+resource RX_BIND_PLUG 1 NONE
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_SCK 4 NONE
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MISO 4 NONE
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource SPI_MOSI 4 NONE
+resource ADC_BATT 1 C02
+resource ADC_CURR 1 C01
+resource ADC_RSSI 1 NONE
+resource ADC_BEC 1 C03
+resource ADC_BUS 1 NONE
+resource ADC_EXT 1 NONE
+resource BARO_CS 1 NONE
+resource BARO_EOC 1 NONE
+resource BARO_XCLR 1 NONE
+resource COMPASS_CS 1 NONE
+resource COMPASS_EXTI 1 NONE
+resource SDCARD_CS 1 NONE
+resource SDCARD_DETECT 1 NONE
+resource PINIO 1 NONE
+resource PINIO 2 NONE
+resource PINIO 3 NONE
+resource PINIO 4 NONE
+resource USB_MSC_PIN 1 NONE
+resource FLASH_CS 1 A15
+resource GYRO_EXTI 1 C04
+resource GYRO_EXTI 2 NONE
+resource GYRO_CS 1 A04
+resource GYRO_CS 2 NONE
+resource ACC_CS 1 NONE
+resource ACC_CS 2 NONE
+resource GYRO_CLK 1 A03
+resource GYRO_CLK 2 NONE
+resource USB_DETECT 1 B12
+resource PULLUP 1 NONE
+resource PULLUP 2 NONE
+resource PULLUP 3 NONE
+resource PULLUP 4 NONE
+resource PULLDOWN 1 NONE
+resource PULLDOWN 2 NONE
+resource PULLDOWN 3 NONE
+resource PULLDOWN 4 NONE
+resource FREQ 1 A02
+resource FREQ 2 NONE
+resource FREQ 3 NONE
+resource FREQ 4 NONE
+
+# timer
+timer C06 AF3
+# pin C06: TIM8 CH1 (AF3)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer B11 AF1
+# pin B11: TIM2 CH4 (AF1)
+timer B10 AF1
+# pin B10: TIM2 CH3 (AF1)
+timer A10 AF1
+# pin A10: TIM1 CH3 (AF1)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+timer A03 AF3
+# pin A03: TIM9 CH2 (AF3)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B01 AF2
+# pin B01: TIM3 CH4 (AF2)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF2
+# pin C09: TIM3 CH4 (AF2)
+timer A02 AF2
+# pin A02: TIM5 CH3 (AF2)
+
+# dma
+dma SPI_MOSI 1 NONE
+dma SPI_MOSI 2 NONE
+dma SPI_MOSI 3 NONE
+dma SPI_MOSI 4 NONE
+dma SPI_MISO 1 NONE
+dma SPI_MISO 2 NONE
+dma SPI_MISO 3 NONE
+dma SPI_MISO 4 NONE
+dma SPI_TX 1 NONE
+dma SPI_TX 2 NONE
+dma SPI_TX 3 NONE
+dma SPI_TX 4 NONE
+dma SPI_RX 1 NONE
+dma SPI_RX 2 NONE
+dma SPI_RX 3 NONE
+dma SPI_RX 4 NONE
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma ADC 2 NONE
+dma ADC 3 NONE
+dma UART_TX 1 NONE
+dma UART_TX 2 NONE
+dma UART_TX 3 NONE
+dma UART_TX 4 NONE
+dma UART_TX 5 NONE
+dma UART_TX 6 NONE
+dma UART_TX 7 NONE
+dma UART_TX 8 NONE
+dma UART_RX 1 NONE
+dma UART_RX 2 NONE
+dma UART_RX 3 NONE
+dma UART_RX 4 NONE
+dma UART_RX 5 NONE
+dma UART_RX 6 NONE
+dma UART_RX 7 NONE
+dma UART_RX 8 NONE
+dma pin C06 1
+# pin C06: DMA2 Stream 2 Channel 7
+dma pin C07 0
+# pin C07: DMA2 Stream 2 Channel 0
+dma pin B11 NONE
+dma pin B10 NONE
+dma pin A10 NONE
+dma pin A15 NONE
+dma pin B09 NONE
+dma pin A03 NONE
+dma pin A08 NONE
+dma pin B01 0
+# pin B01: DMA1 Stream 2 Channel 5
+dma pin C08 NONE
+dma pin C09 NONE
+dma pin A02 NONE
+
+# feature
+feature -RX_PPM
+feature -RX_SERIAL
+feature -SOFTSERIAL
+feature -GPS
+feature -RANGEFINDER
+feature -TELEMETRY
+feature -RX_PARALLEL_PWM
+feature -RX_MSP
+feature -RSSI_ADC
+feature -LED_STRIP
+feature -DASHBOARD
+feature -OSD
+feature -CMS
+feature -RX_SPI
+feature -GOVERNOR
+feature -ESC_SENSOR
+feature -FREQ_SENSOR
+feature -DYN_NOTCH
+feature -RPM_FILTER
+feature RX_SERIAL
+feature TELEMETRY
+feature LED_STRIP
+feature GOVERNOR
+feature ESC_SENSOR
+feature DYN_NOTCH
+feature RPM_FILTER
+
+# serial
+serial 20 1 115200 57600 0 115200
+serial 2 0 115200 57600 0 115200
+serial 3 64 115200 57600 0 115200
+serial 4 1024 115200 57600 0 115200
+
+# servo
+# PWM Servos
+servo 1 1500 -700 700 500 500 333 0 3
+servo 2 1500 -700 700 500 500 333 0 3
+servo 3 1500 -700 700 500 500 333 0 3
+servo 4 750 -300 300 300 300 400 0 0
+
+# map
+map AECR1T23
+
+
+
+
+# master
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_i2cBus = 0
+set gyro_1_i2c_address = 0
+set gyro_1_sensor_align = CW90
+set gyro_1_align_roll = 0
+set gyro_1_align_pitch = 0
+set gyro_1_align_yaw = 0
+set baro_bustype = I2C
+set baro_spi_device = 0
+set baro_i2c_device = 1
+set baro_i2c_address = 0
+set baro_hardware = AUTO
+set i2c1_pullup = ON
+set i2c1_clockspeed_khz = 800
+set i2c2_pullup = ON
+set i2c2_clockspeed_khz = 800
+set i2c3_pullup = ON
+set i2c3_clockspeed_khz = 800
+set flash_spi_bus = 3
+set blackbox_device = SPIFLASH
+set blackbox_rate_denom = 16
+set adc_device = 1
+set adc_vrefint_calibration = 0
+set adc_tempsensor_calibration30 = 0
+set adc_tempsensor_calibration110 = 0
+set current_meter = ADC
+set battery_meter = ADC
+set vbat_scale = 110
+set vbat_divider = 10
+set beeper_inversion = ON
+set beeper_od = OFF
+set motor_pwm_protocol = DSHOT300
+set serialrx_provider = CRSF
+set pid_process_denom = 4


### PR DESCRIPTION
Target configuration for the MoLite200 flight controller based on STM32F7X2.
This board is designed specifically for the XLPOWER Stratos 200 helicopter
and is now in mass production and this target file have been tested.
<img width="1706" height="1279" alt="129563" src="https://github.com/user-attachments/assets/25dd830a-73a8-41cb-b8ff-2a8b126dae35" />
